### PR TITLE
shorter version of lodash functional

### DIFF
--- a/src/03-functional-with-lodash.js
+++ b/src/03-functional-with-lodash.js
@@ -1,18 +1,6 @@
 var numbers = [3, 1, 7];
 var constant = 2;
 
-function mul(a, b) {
-  return a * b;
-}
-function print(n) {
-  console.log(n);
-}
-
 var _ = require('lodash');
-var byConstant = _.partial(mul, constant);
 
-_.forEach(
-  _.map(numbers, byConstant),
-  print
-);
-// 6 2 14
+_.map(numbers, number => console.log(number * constant));


### PR DESCRIPTION
In a real world app I would leave out `console.log` and assign the result of `_.map` to a variable, but your other examples also only log it.
